### PR TITLE
Downgrade font-awesome dependency to 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>font-awesome</artifactId>
-            <version>6.4.0</version>
+            <version>5.15.4</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>


### PR DESCRIPTION
escape-velocity template is not compatible with 6.x